### PR TITLE
Add unit tests for sim::kernels

### DIFF
--- a/core/src/sim/kernels.rs
+++ b/core/src/sim/kernels.rs
@@ -46,3 +46,116 @@ pub fn expected_mutation_counts(lineages: &LineagesData, eligible_N: &[f64]) -> 
         .map(|(u, n)| u * n * 2.0)
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sim::types::SecondaryLineageData;
+    use approx::assert_relative_eq;
+
+    fn make_lineages(data: &[(f64, f64, f64)]) -> LineagesData {
+        let mut lineages = LineagesData::default();
+        for &(n, w, u) in data {
+            lineages.N.push(n);
+            lineages.W.push(w);
+            lineages.U.push(u);
+            lineages.secondary.push(SecondaryLineageData::default());
+        }
+        lineages
+    }
+
+    #[test]
+    fn test_grow_lineages_uniform_fitness() {
+        // W=1.0, delta_t=1.0 → N doubles: N_new = N * 2^(1.0*1.0) = 2*N
+        let mut lineages = make_lineages(&[(100.0, 1.0, 0.0), (200.0, 1.0, 0.0)]);
+        grow_lineages_inplace(&mut lineages, 1.0);
+        assert_relative_eq!(lineages.N[0], 200.0, epsilon = 1e-10);
+        assert_relative_eq!(lineages.N[1], 400.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_grow_lineages_higher_fitness_grows_faster() {
+        // W=2.0, delta_t=1.0 → N_new = N * 2^(2.0*1.0) = 4*N
+        let mut lineages = make_lineages(&[(100.0, 2.0, 0.0)]);
+        grow_lineages_inplace(&mut lineages, 1.0);
+        assert_relative_eq!(lineages.N[0], 400.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_grow_lineages_fractional_delta_t() {
+        // W=1.0, delta_t=0.5 → N_new = N * 2^0.5 = N * sqrt(2)
+        let mut lineages = make_lineages(&[(100.0, 1.0, 0.0)]);
+        grow_lineages_inplace(&mut lineages, 0.5);
+        assert_relative_eq!(lineages.N[0], 100.0 * 2.0_f64.sqrt(), epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_grow_lineages_zero_delta_t() {
+        // delta_t=0 → no growth
+        let mut lineages = make_lineages(&[(100.0, 1.5, 0.0)]);
+        grow_lineages_inplace(&mut lineages, 0.0);
+        assert_relative_eq!(lineages.N[0], 100.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_old_n_to_delta_n() {
+        let lineages = make_lineages(&[(200.0, 1.0, 0.0), (500.0, 1.0, 0.0)]);
+        let mut old_n = vec![100.0, 300.0];
+        let delta_n = old_N_to_delta_N(&lineages, &mut old_n);
+        assert_relative_eq!(delta_n[0], 100.0, epsilon = 1e-10);
+        assert_relative_eq!(delta_n[1], 200.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_old_n_to_delta_n_no_growth() {
+        let lineages = make_lineages(&[(100.0, 1.0, 0.0)]);
+        let mut old_n = vec![100.0];
+        let delta_n = old_N_to_delta_N(&lineages, &mut old_n);
+        assert_relative_eq!(delta_n[0], 0.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_expected_mutation_counts_basic() {
+        // U=0.001, eligible_N=1000 → expected = 0.001 * 1000 * 2 = 2.0
+        let lineages = make_lineages(&[(0.0, 1.0, 0.001)]);
+        let eligible = vec![1000.0];
+        let counts = expected_mutation_counts(&lineages, &eligible);
+        assert_relative_eq!(counts[0], 2.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_expected_mutation_counts_zero_rate() {
+        let lineages = make_lineages(&[(0.0, 1.0, 0.0)]);
+        let eligible = vec![500.0];
+        let counts = expected_mutation_counts(&lineages, &eligible);
+        assert_relative_eq!(counts[0], 0.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_expected_mutation_counts_multiple() {
+        let lineages = make_lineages(&[(0.0, 1.0, 0.01), (0.0, 1.0, 0.02)]);
+        let eligible = vec![100.0, 200.0];
+        let counts = expected_mutation_counts(&lineages, &eligible);
+        // 0.01 * 100 * 2 = 2.0
+        assert_relative_eq!(counts[0], 2.0, epsilon = 1e-10);
+        // 0.02 * 200 * 2 = 8.0
+        assert_relative_eq!(counts[1], 8.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_grow_lineages_mismatched_lengths_panics() {
+        let mut lineages = LineagesData::default();
+        lineages.N.push(100.0);
+        // W is empty — mismatch
+        grow_lineages_inplace(&mut lineages, 1.0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_expected_mutation_counts_mismatched_lengths_panics() {
+        let lineages = make_lineages(&[(100.0, 1.0, 0.01)]);
+        let eligible = vec![100.0, 200.0]; // wrong length
+        expected_mutation_counts(&lineages, &eligible);
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/zachmatson/STEPS/issues/8

## Summary
- Adds 11 inline unit tests for `core/src/sim/kernels.rs`
- Covers: grow_lineages_inplace (uniform, high fitness, fractional delta_t, zero delta_t), old_N_to_delta_N, expected_mutation_counts, panic on mismatched lengths

## Test plan
- [x] `cargo test -p steps_core` passes all tests