### PR TITLE
Add crates.io publish metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 version = "2.0.1"
+license = "GPL-3.0"
+repository = "https://github.com/zachmatson/STEPS"
+description = "Serially Transferred Evolving Population Simulator"
+keywords = ["evolution", "simulation", "population-genetics", "microbiology"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,6 +2,10 @@
 name = "steps_cli"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "CLI for STEPS (Serially Transferred Evolving Population Simulator)"
+keywords.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,6 +2,10 @@
 name = "steps_core"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Core simulation library for STEPS"
+keywords.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Summary
- Adds `license`, `repository`, `description`, and `keywords` to workspace and crate Cargo.toml files
- These fields are required for `cargo publish` to crates.io

After merging, publishing is just `cargo publish -p steps_core && cargo publish -p steps_cli`.

Closes #14